### PR TITLE
Create derived copies of content on 'Publish'

### DIFF
--- a/web/admin/package.json
+++ b/web/admin/package.json
@@ -5,7 +5,7 @@
   "homepage": ".",
   "dependencies": {
     "@doubledutch/admin-client": "^1.0.2",
-    "@doubledutch/firebase-connector": "^3.2.3",
+    "@doubledutch/firebase-connector": "^3.3.0",
     "moment": "^2.20.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",

--- a/web/admin/src/App.js
+++ b/web/admin/src/App.js
@@ -66,6 +66,10 @@ export default class App extends PureComponent {
               ? <button onClick={() => pendingContentRef().child(c.key).update({attendeeIds: []})}>- attendee</button>
               : <button onClick={() => pendingContentRef().child(c.key).update({attendeeIds: [24601]})}>+ attendee</button>
             }
+            {c.tierIds.length
+              ? <button onClick={() => pendingContentRef().child(c.key).update({tierIds: []})}>- tiers</button>
+              : <span><button onClick={() => pendingContentRef().child(c.key).update({tierIds: [42]})}>+ tier</button><button onClick={() => pendingContentRef().child(c.key).update({tierIds: ['default', 42]})}>+ tiers</button></span>
+            }
             {JSON.stringify(c)}
           </li>
         ))}</ul>
@@ -78,7 +82,7 @@ export default class App extends PureComponent {
       // 1. Remove all derived copies
       publicContentRef().remove()
       usersRef().remove()
-      //tiersRef().remove()
+      tiersRef().remove()
 
       // 2. Create derived copies from `pendingContent`
       
@@ -96,7 +100,7 @@ export default class App extends PureComponent {
       usersRef().set(getDerivedCopiesGroupedBy(this.state.pendingContent, 'attendeeIds'))
 
       // 2c. Tiers bucket gets a copy for each tier
-      // tiersRef().set(getDerivedCopiesGroupedBy(this.state.pendingContent, 'tierIds'))
+      tiersRef().set(getDerivedCopiesGroupedBy(this.state.pendingContent, 'tierIds'))
       
       // 3. Copy `pendingContent` to `content`
       contentRef().set(contentArrayToFirebaseObject(this.state.pendingContent))
@@ -153,4 +157,4 @@ const lastPublishedAtRef = () => fbc.database.private.adminRef('lastPublishedAt'
 
 const publicContentRef = () => fbc.database.public.adminRef('content')
 const usersRef = userId => fbc.database.private.adminableUsersRef(userId)
-//const tiersRef = tierId => fbc.database.private.tiersRef(tierId)
+const tiersRef = tierId => fbc.database.private.tiersRef(tierId)

--- a/web/admin/yarn.lock
+++ b/web/admin/yarn.lock
@@ -8,9 +8,9 @@
   dependencies:
     babel-runtime "^6.26.0"
 
-"@doubledutch/firebase-connector@^3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@doubledutch/firebase-connector/-/firebase-connector-3.2.3.tgz#606f87f259447e10e9477e3693912676cfba5e0a"
+"@doubledutch/firebase-connector@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@doubledutch/firebase-connector/-/firebase-connector-3.3.0.tgz#1365402b9b019a2c0d812e9bb5cd6cff0a76c7c5"
   dependencies:
     babel-runtime "^6.26.0"
     firebase "^4.6.0"


### PR DESCRIPTION
Data was already copied for the public bucket (no filters, or only attendee group filters)

With these changes, copies are also created for individual users and tiers.